### PR TITLE
Adding support for KV-only clusters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.couchbase.client:java-client:3.4.6")
+    implementation("com.couchbase.client:java-client:3.4.9")
     implementation("org.slf4j:slf4j-simple:2.0.7")
     implementation("org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r")
     testImplementation("org.mockito:mockito-core:5.2.0")
@@ -27,7 +27,7 @@ dependencies {
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2021.3.3")
+    version.set("2022.3.3")
     type.set("IC") // Target IDE Platform
 
     plugins.set(listOf(/* Plugin Dependencies */))

--- a/src/main/java/com/couchbase/intellij/tools/CBExport.java
+++ b/src/main/java/com/couchbase/intellij/tools/CBExport.java
@@ -99,7 +99,7 @@ public class CBExport {
                 .collect(Collectors.toList());
 
         boolean idx = false;
-        if (hasIndexes(bucket, scope, collections)) {
+        if (ActiveCluster.getInstance().hasQueryService() && hasIndexes(bucket, scope, collections)) {
             int result = Messages.showYesNoDialog("<html>Would you like to also export the indexes of the scope <strong>" + scope + "</strong>?</html>",
                     "Simple Export", Messages.getQuestionIcon());
 

--- a/src/main/java/com/couchbase/intellij/tools/CBImport.java
+++ b/src/main/java/com/couchbase/intellij/tools/CBImport.java
@@ -165,6 +165,10 @@ public class CBImport {
     }
 
     private static boolean shouldImportIndexes(ExportedMetadata meta) {
+
+        if(!ActiveCluster.getInstance().hasQueryService()) {
+            return false;
+        }
         boolean idx = false;
         if (!meta.getIndexes().isEmpty()) {
             int result = Messages.showYesNoDialog("<html>This dataset contain indexes. Would you like to also create them?" + "<br><small>If the indexes already exist in your environment, they won't be recreated.</small></html>", "Simple Import", Messages.getQuestionIcon());

--- a/src/main/java/com/couchbase/intellij/tree/CouchbaseWindowContent.java
+++ b/src/main/java/com/couchbase/intellij/tree/CouchbaseWindowContent.java
@@ -155,21 +155,6 @@ public class CouchbaseWindowContent extends JPanel {
         return new DefaultTreeModel(root);
     }
 
-    public Icon combine(ImageIcon icon1, ImageIcon icon2) {
-        // Create a new image that's the sum of both icon widths and the height of the taller one
-        int w = icon1.getIconWidth() + icon2.getIconWidth();
-        int h = Math.max(icon1.getIconHeight(), icon2.getIconHeight());
-        BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
-
-        // Paint both icons onto this image
-        Graphics2D g = image.createGraphics();
-        g.drawImage(icon1.getImage(), 0, 0, null);
-        g.drawImage(icon2.getImage(), icon1.getIconWidth(), 0, null);
-        g.dispose();
-
-        return new ImageIcon(image);
-    }
-
     static class NodeDescriptorRenderer extends DefaultTreeCellRenderer {
         @Override
         public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {

--- a/src/main/java/com/couchbase/intellij/tree/CouchbaseWindowFactory.java
+++ b/src/main/java/com/couchbase/intellij/tree/CouchbaseWindowFactory.java
@@ -11,7 +11,7 @@ public class CouchbaseWindowFactory implements ToolWindowFactory {
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
         CouchbaseWindowContent couchbaseWindowContent = new CouchbaseWindowContent(project);
-        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+        ContentFactory contentFactory = ContentFactory.getInstance();
         Content content = contentFactory.createContent(couchbaseWindowContent, "Explorer", false);
         toolWindow.getContentManager().addContent(content);
     }

--- a/src/main/java/com/couchbase/intellij/tree/OpenDocumentDialog.java
+++ b/src/main/java/com/couchbase/intellij/tree/OpenDocumentDialog.java
@@ -99,7 +99,7 @@ public class OpenDocumentDialog extends DialogWrapper {
         gc.weightx = 0.6;
         formPanel.add(textField, gc);
 
-        if (createDocument) {
+        if (createDocument && ActiveCluster.getInstance().hasQueryService()) {
             gc.gridy = 1;
             gc.gridx = 1;
             gc.weightx = 1;

--- a/src/main/java/com/couchbase/intellij/tree/TreeActionHandler.java
+++ b/src/main/java/com/couchbase/intellij/tree/TreeActionHandler.java
@@ -87,20 +87,11 @@ public class TreeActionHandler {
                 }
                 CompletableFuture.runAsync(() -> {
                     try {
-                        ServerOverview overview = CouchbaseRestAPI.getOverview();
-                        ActiveCluster.getInstance().setServices(overview.getNodes().stream()
-                                .flatMap(node -> node.getServices().stream()).distinct().collect(Collectors.toList()));
-
-                        ActiveCluster.getInstance().setVersion(overview.getNodes().get(0).getVersion()
-                                .substring(0, overview.getNodes().get(0).getVersion().indexOf('-')));
 
                         if (!CBConfigUtil.isSupported(ActiveCluster.getInstance().getVersion())) {
                             SwingUtilities.invokeLater(() -> Messages.showErrorDialog("<html>This plugin doesn't work with versions bellow Couchbase 7.0</html>", "Couchbase Plugin Error"));
                         }
 
-                        if (!CBConfigUtil.hasQueryService(ActiveCluster.getInstance().getServices())) {
-                            SwingUtilities.invokeLater(() -> Messages.showErrorDialog("<html>Your cluster doesn't have the Query Service. Some features might not work properly.</html>", "Couchbase Plugin Error"));
-                        }
                     } catch (Exception e) {
                         e.printStackTrace();
                         Log.error("Could not call the RestAPI to get an overview of the service.", e);

--- a/src/main/java/com/couchbase/intellij/tree/TreeToolBarBuilder.java
+++ b/src/main/java/com/couchbase/intellij/tree/TreeToolBarBuilder.java
@@ -46,6 +46,12 @@ public class TreeToolBarBuilder {
                     }
                 });
             }
+
+            @Override
+            public void update(AnActionEvent e) {
+                boolean shouldEnable = ActiveCluster.getInstance().hasQueryService();
+                e.getPresentation().setEnabled(shouldEnable);
+            }
         };
 
         newWorkbench.getTemplatePresentation().setIcon(IconLoader.getIcon("/assets/icons/new_query.svg", CouchbaseWindowContent.class));
@@ -97,6 +103,7 @@ public class TreeToolBarBuilder {
         DefaultActionGroup leftActionGroup = new DefaultActionGroup();
         leftActionGroup.add(addConnectionAction);
         leftActionGroup.addSeparator();
+
         leftActionGroup.add(newWorkbench);
         leftActionGroup.addSeparator();
 
@@ -115,6 +122,13 @@ public class TreeToolBarBuilder {
         ActionToolbar rightActionToolbar = ActionManager.getInstance().createActionToolbar("MoreOptions", rightActionGroup, true);
         rightActionToolbar.setTargetComponent(toolBarPanel);
         toolBarPanel.add(rightActionToolbar.getComponent(), BorderLayout.EAST);
+
+        ActiveCluster.getInstance().registerNewConnectionListener(() -> {
+            SwingUtilities.invokeLater(() -> {
+                leftActionToolbar.updateActionsImmediately();
+                toolBarPanel.revalidate();
+            });
+        });
 
         return toolBarPanel;
     }

--- a/src/main/java/com/couchbase/intellij/tree/node/FileNodeDescriptor.java
+++ b/src/main/java/com/couchbase/intellij/tree/node/FileNodeDescriptor.java
@@ -2,7 +2,6 @@ package com.couchbase.intellij.tree.node;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.json.JsonFileType;
-import com.intellij.openapi.fileTypes.UserBinaryFileType;
 import com.intellij.openapi.vfs.VirtualFile;
 
 public class FileNodeDescriptor extends NodeDescriptor {
@@ -16,7 +15,7 @@ public class FileNodeDescriptor extends NodeDescriptor {
     private FileType type;
 
     public FileNodeDescriptor(String name, String bucket, String scope, String collection, String id, FileType type, VirtualFile virtualFile) {
-        super(name, type==FileType.BINARY? AllIcons.FileTypes.Any_type :JsonFileType.INSTANCE.getIcon());
+        super(name, type==FileType.JSON? JsonFileType.INSTANCE.getIcon():AllIcons.FileTypes.Any_type);
         this.virtualFile = virtualFile;
         this.bucket = bucket;
         this.scope = scope;
@@ -59,6 +58,7 @@ public class FileNodeDescriptor extends NodeDescriptor {
 
     public static enum FileType {
         JSON,
-        BINARY
+        BINARY,
+        UNKNOWN
     }
 }

--- a/src/main/java/com/couchbase/intellij/tree/overview/IndexOverviewDialog.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/IndexOverviewDialog.java
@@ -3,6 +3,7 @@ package com.couchbase.intellij.tree.overview;
 import com.couchbase.intellij.tree.overview.apis.CouchbaseRestAPI;
 import com.couchbase.intellij.tree.overview.apis.IndexStats;
 import com.couchbase.intellij.workbench.Log;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.ui.JBUI;
@@ -22,8 +23,8 @@ public class IndexOverviewDialog extends DialogWrapper {
     private final String collection;
     private final String indexName;
 
-    public IndexOverviewDialog(String bucket, String scope, String collection, String indexName) {
-        super(null);
+    public IndexOverviewDialog(Project project, String bucket, String scope, String collection, String indexName) {
+        super(project);
         this.bucket = bucket;
         this.scope = scope;
         this.collection = collection;

--- a/src/main/java/com/couchbase/intellij/tree/overview/apis/CouchbaseRestAPI.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/apis/CouchbaseRestAPI.java
@@ -1,7 +1,10 @@
 package com.couchbase.intellij.tree.overview.apis;
 
 import com.couchbase.client.core.deps.com.google.common.reflect.TypeToken;
+import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.intellij.database.ActiveCluster;
+import com.couchbase.intellij.tree.overview.range.Range;
+import com.couchbase.intellij.tree.overview.range.RangeData;
 import com.couchbase.intellij.workbench.Log;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13,6 +16,7 @@ import javax.net.ssl.X509TrustManager;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Base64;
@@ -21,9 +25,75 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.lang.reflect.Type;
 
 public class CouchbaseRestAPI {
 
+    public static String getMetaDocument(String bucket, String scope, String collection, String id ) throws Exception {
+        String result = callSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/default/buckets/"
+                        +bucket+"/scopes/"+scope+"/collections/"+collection+"/docs/"+id, ActiveCluster.getInstance().getClusterURL());
+
+        JsonObject object = JsonObject.fromJson(result);
+        object.removeKey("json");
+        return object.toString();
+    }
+    public static List<String> listKVDocuments(String bucket, String scope, String collection, int skip, int limit ) throws Exception {
+        String result = callSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/default/buckets/"
+                        +bucket+"/scopes/"+scope+"/collections/"+collection+"/docs?skip="+skip+"&limit="+limit+"&include_doc=false",
+                ActiveCluster.getInstance().getClusterURL());
+
+        Gson gson = new Gson();
+        KVDocsList response = gson.fromJson(result, KVDocsList.class);
+
+        return response.getRows().stream()
+                .map(KVRow::getId)
+                .collect(Collectors.toList());
+    }
+    public static Map<String, Integer> getCollectionCounts(String bucket, String scope) throws Exception {
+
+        String payload = "[\n" +
+                "  {\n" +
+                "    \"step\": 3,\n" +
+                "    \"timeWindow\": 360,\n" +
+                "    \"start\": -3,\n" +
+                "    \"metric\": [\n" +
+                "      {\n" +
+                "        \"label\": \"name\",\n" +
+                "        \"value\": \"kv_collection_item_count\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"label\": \"bucket\",\n" +
+                "        \"value\": \""+bucket+"\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"label\": \"scope\",\n" +
+                "        \"value\": \""+scope+"\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"nodesAggregation\": \"sum\"\n" +
+                "  }\n" +
+                "]";
+
+        String content = callPostSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/default/stats/range/",
+                ActiveCluster.getInstance().getClusterURL(), payload);
+
+        Gson gson = new GsonBuilder().create();
+
+        Type listType = new TypeToken<List<Range>>() {
+        }.getType();
+        List<Range> ranges = gson.fromJson(content, listType);
+
+        Map<String, Integer> result = new HashMap<>();
+        for (Range range : ranges) {
+            for (RangeData data : range.getData()) {
+                if ("kv_collection_item_count".equals(data.getMetric().getName())) {
+                    result.put(data.getMetric().getBucket() + "." + data.getMetric().getScope() + "." + data.getMetric().getCollection(),
+                            Integer.valueOf(data.getValues().get(0).get(1).toString()));
+                }
+            }
+        }
+        return result;
+    }
 
     public static Map<String, IndexStats> getIndexStats(String bucket, String scope, String collection, String indexName) throws Exception {
 
@@ -34,8 +104,7 @@ public class CouchbaseRestAPI {
             key += ":" + scope + ":" + collection + ":" + indexName;
         }
 
-        List<String> calls = callAllEndpoints((ActiveCluster.getInstance().isSSLEnabled() ? "19102" : "9102") + "/api/v1/stats/" + bucket + "." + scope + "." + collection, ActiveCluster.getInstance().getClusterURL(),
-                ActiveCluster.getInstance().isSSLEnabled(), ActiveCluster.getInstance().getUsername(), ActiveCluster.getInstance().getPassword());
+        List<String> calls = callAllEndpoints((ActiveCluster.getInstance().isSSLEnabled() ? "19102" : "9102") + "/api/v1/stats/" + bucket + "." + scope + "." + collection, ActiveCluster.getInstance().getClusterURL());
 
         Log.debug("Endpoint results " + calls.size());
         Gson gson = new GsonBuilder().create();
@@ -64,32 +133,30 @@ public class CouchbaseRestAPI {
 
     public static ServerOverview getOverview() throws Exception {
 
-        String content = callSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/nodes", ActiveCluster.getInstance().getClusterURL(),
-                ActiveCluster.getInstance().isSSLEnabled(), ActiveCluster.getInstance().getUsername(), ActiveCluster.getInstance().getPassword());
+        String content = callSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/nodes", ActiveCluster.getInstance().getClusterURL());
         Gson gson = new GsonBuilder().serializeNulls().create();
         return gson.fromJson(content, ServerOverview.class);
     }
 
     public static BucketOverview getBucketOverview(String bucket) throws Exception {
 
-        String content = callSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/default/buckets/" + bucket, ActiveCluster.getInstance().getClusterURL(),
-                ActiveCluster.getInstance().isSSLEnabled(), ActiveCluster.getInstance().getUsername(), ActiveCluster.getInstance().getPassword());
+        String content = callSingleEndpoint((ActiveCluster.getInstance().isSSLEnabled() ? "18091" : "8091") + "/pools/default/buckets/" + bucket, ActiveCluster.getInstance().getClusterURL());
         Gson gson = new GsonBuilder().serializeNulls().create();
         return gson.fromJson(content, BucketOverview.class);
     }
 
-    private static String callSingleEndpoint(String endpoint, String cbURL, boolean isSSL, String username, String password) throws Exception {
+    private static String callSingleEndpoint(String endpoint, String cbURL) throws Exception {
         List<String> servers = NSLookup.getServerURL(cbURL);
-        return callEndpoint(endpoint, servers.get(0), isSSL, username, password);
+        return callGetEndpoint(endpoint, servers.get(0));
     }
 
-    private static List<String> callAllEndpoints(String endpoint, String cbURL, boolean isSSL, String username, String password) throws Exception {
+    private static List<String> callAllEndpoints(String endpoint, String cbURL) throws Exception {
         List<String> servers = NSLookup.getServerURL(cbURL);
         Log.debug("Servers Found:" + servers.toString());
         List<CompletableFuture<String>> futureList = servers.parallelStream()
                 .map(key -> CompletableFuture.supplyAsync(() -> {
                     try {
-                        return callEndpoint(endpoint, key, isSSL, username, password);
+                        return callGetEndpoint(endpoint, key);
                     } catch (Exception e) {
                         return null;
                     }
@@ -102,17 +169,27 @@ public class CouchbaseRestAPI {
 
     }
 
-    private static String callEndpoint(String endpoint, String serverURL, boolean isSSL, String username, String password) throws Exception {
+    private static String callPostSingleEndpoint(String endpoint, String serverURL, String data) throws Exception {
+        List<String> servers = NSLookup.getServerURL(serverURL);
+        return callEndpoint(false, endpoint, servers.get(0), data);
+    }
 
-        String userpass = username + ":" + password;
+    private static String callGetEndpoint(String endpoint, String serverURL) throws Exception {
+        return callEndpoint(true, endpoint, serverURL, null);
+    }
+
+    private static String callEndpoint(boolean isGet, String endpoint, String serverURL, String data) throws Exception {
+
+        String userpass = ActiveCluster.getInstance().getUsername() + ":" + ActiveCluster.getInstance().getPassword();
         String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userpass.getBytes()));
 
-        String urlContent = (isSSL ? "https://" : "http://") + serverURL + ":" + endpoint;
+        String urlContent = (ActiveCluster.getInstance().isSSLEnabled() ? "https://" : "http://") + serverURL + ":" + endpoint;
         URL url = new URL(urlContent);
         InputStream stream;
 
-        if (isSSL) {
-            HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        HttpURLConnection conn =  null;
+        if (ActiveCluster.getInstance().isSSLEnabled()) {
+            conn  = (HttpsURLConnection) url.openConnection();
             TrustManager[] trustAllCerts = new TrustManager[]{
                     new X509TrustManager() {
                         public java.security.cert.X509Certificate[] getAcceptedIssuers() {
@@ -128,16 +205,24 @@ public class CouchbaseRestAPI {
             };
             SSLContext sc = SSLContext.getInstance("SSL");
             sc.init(null, trustAllCerts, new java.security.SecureRandom());
-            conn.setSSLSocketFactory(sc.getSocketFactory());
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Authorization", basicAuth);
-            stream = conn.getInputStream();
+            ((HttpsURLConnection) conn).setSSLSocketFactory(sc.getSocketFactory());
         } else {
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Authorization", basicAuth);
-            stream = conn.getInputStream();
+            conn = (HttpURLConnection) url.openConnection();
         }
+
+        conn.setRequestMethod(isGet?"GET":"POST");
+        conn.setRequestProperty("Authorization", basicAuth);
+        if(!isGet) {
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+
+            try (OutputStream os = conn.getOutputStream()) {
+                byte[] input = data.getBytes("utf-8");
+                os.write(input, 0, input.length);
+            }
+        }
+
+        stream = conn.getInputStream();
 
 
         BufferedReader in = new BufferedReader(new InputStreamReader(stream));

--- a/src/main/java/com/couchbase/intellij/tree/overview/apis/KVDocsList.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/apis/KVDocsList.java
@@ -1,0 +1,16 @@
+package com.couchbase.intellij.tree.overview.apis;
+
+import java.util.List;
+
+public class KVDocsList {
+
+    private List<KVRow> rows;
+
+    public List<KVRow> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<KVRow> rows) {
+        this.rows = rows;
+    }
+}

--- a/src/main/java/com/couchbase/intellij/tree/overview/apis/KVRow.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/apis/KVRow.java
@@ -1,0 +1,14 @@
+package com.couchbase.intellij.tree.overview.apis;
+
+public class KVRow {
+
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/couchbase/intellij/tree/overview/range/Range.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/range/Range.java
@@ -1,0 +1,34 @@
+package com.couchbase.intellij.tree.overview.range;
+
+import java.util.List;
+
+public class Range {
+
+    private List<RangeData> data;
+    private long startTimestamp;
+    private long endTimestamp;
+
+    public List<RangeData> getData() {
+        return data;
+    }
+
+    public void setData(List<RangeData> data) {
+        this.data = data;
+    }
+
+    public long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    public long getEndTimestamp() {
+        return endTimestamp;
+    }
+
+    public void setEndTimestamp(long endTimestamp) {
+        this.endTimestamp = endTimestamp;
+    }
+}

--- a/src/main/java/com/couchbase/intellij/tree/overview/range/RangeData.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/range/RangeData.java
@@ -1,0 +1,25 @@
+package com.couchbase.intellij.tree.overview.range;
+
+import java.util.List;
+
+public class RangeData {
+
+    private RangeMetric metric;
+    private List<List<Object>> values;
+
+    public RangeMetric getMetric() {
+        return metric;
+    }
+
+    public void setMetric(RangeMetric metric) {
+        this.metric = metric;
+    }
+
+    public List<List<Object>> getValues() {
+        return values;
+    }
+
+    public void setValues(List<List<Object>> values) {
+        this.values = values;
+    }
+}

--- a/src/main/java/com/couchbase/intellij/tree/overview/range/RangeMetric.java
+++ b/src/main/java/com/couchbase/intellij/tree/overview/range/RangeMetric.java
@@ -1,0 +1,81 @@
+package com.couchbase.intellij.tree.overview.range;
+
+import java.util.List;
+
+public class RangeMetric {
+
+    private List<String> nodes;
+
+    private String bucket;
+    private String collection;
+    private String collection_id;
+    private String instance;
+    private String name;//"kv_collection_item_count"
+    private String scope;
+    private String scope_id;
+
+
+    public List<String> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<String> nodes) {
+        this.nodes = nodes;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public void setCollection(String collection) {
+        this.collection = collection;
+    }
+
+    public String getCollection_id() {
+        return collection_id;
+    }
+
+    public void setCollection_id(String collection_id) {
+        this.collection_id = collection_id;
+    }
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getScope_id() {
+        return scope_id;
+    }
+
+    public void setScope_id(String scope_id) {
+        this.scope_id = scope_id;
+    }
+}

--- a/src/main/java/com/couchbase/intellij/workbench/CustomSqlFileEditor.java
+++ b/src/main/java/com/couchbase/intellij/workbench/CustomSqlFileEditor.java
@@ -155,7 +155,7 @@ public class CustomSqlFileEditor implements FileEditor {
         executeGroup.add(new AnAction("Favorite List", "List of favorite queries", favoriteList) {
             @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
-                FavoriteQueryDialog dialog = new FavoriteQueryDialog(queryEditor.getDocument());
+                FavoriteQueryDialog dialog = new FavoriteQueryDialog(project, queryEditor.getDocument());
                 dialog.show();
             }
         });
@@ -235,7 +235,7 @@ public class CustomSqlFileEditor implements FileEditor {
         favoriteActionGroup.add(new AnAction("Favorite Query", "Favorite query", IconLoader.getIcon("/assets/icons/star-empty.svg", CustomSqlFileEditor.class)) {
             @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
-                NewFavoriteCatalog dialog = new NewFavoriteCatalog(queryEditor.getDocument(), this, favoriteActionGroup, favToolbar);
+                NewFavoriteCatalog dialog = new NewFavoriteCatalog(project, queryEditor.getDocument(), this, favoriteActionGroup, favToolbar);
                 dialog.show();
             }
         });

--- a/src/main/java/com/couchbase/intellij/workbench/FavoriteQueryDialog.java
+++ b/src/main/java/com/couchbase/intellij/workbench/FavoriteQueryDialog.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.EditorSettings;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.components.JBList;
 import com.intellij.ui.components.JBScrollPane;
@@ -28,8 +29,8 @@ public class FavoriteQueryDialog extends DialogWrapper {
     private final EditorEx editor;
     private final Document document;
 
-    protected FavoriteQueryDialog(Document document) {
-        super(null);
+    protected FavoriteQueryDialog(Project project, Document document) {
+        super(project);
         setTitle("Favorite Queries List");
         this.document = document;
 

--- a/src/main/java/com/couchbase/intellij/workbench/NewFavoriteCatalog.java
+++ b/src/main/java/com/couchbase/intellij/workbench/NewFavoriteCatalog.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.editor.event.DocumentListener;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.util.ui.JBUI;
@@ -27,8 +28,11 @@ public class NewFavoriteCatalog extends DialogWrapper {
     private JTextField textField;
     private JLabel errorLabel;
 
-    protected NewFavoriteCatalog(Document document, AnAction anAction, DefaultActionGroup favoriteActionGroup, ActionToolbar favToolbar) {
-        super(null);
+    private Project project;
+
+    protected NewFavoriteCatalog(Project project, Document document, AnAction anAction, DefaultActionGroup favoriteActionGroup, ActionToolbar favToolbar) {
+        super(project);
+        this.project = project;
         this.document = document;
         this.anAction = anAction;
         this.favoriteActionGroup = favoriteActionGroup;
@@ -104,7 +108,7 @@ public class NewFavoriteCatalog extends DialogWrapper {
                     AnAction newAction = new AnAction("Favorite Query", "Favorite query", IconLoader.getIcon("/assets/icons/star-empty.svg", NewFavoriteCatalog.class)) {
                         @Override
                         public void actionPerformed(@NotNull AnActionEvent e) {
-                            NewFavoriteCatalog dialog = new NewFavoriteCatalog(document, this, favoriteActionGroup, favToolbar);
+                            NewFavoriteCatalog dialog = new NewFavoriteCatalog(project, document, this, favoriteActionGroup, favToolbar);
                             dialog.show();
                         }
                     };

--- a/src/main/java/com/couchbase/intellij/workbench/explain/HtmlPanel.java
+++ b/src/main/java/com/couchbase/intellij/workbench/explain/HtmlPanel.java
@@ -14,7 +14,9 @@ public class HtmlPanel extends JPanel {
         super(new BorderLayout());
         setBackground(Color.decode("#3c3f41"));
         JBCefClient jbCefClient = JBCefApp.getInstance().createClient();
-        jbCefBrowser = new JBCefBrowser(jbCefClient, null);
+        jbCefBrowser = JBCefBrowser.createBuilder().setClient(jbCefClient)
+            .setUrl(null)
+            .build();
         add(jbCefBrowser.getComponent(), BorderLayout.CENTER);
     }
 

--- a/src/main/java/utils/CBConfigUtil.java
+++ b/src/main/java/utils/CBConfigUtil.java
@@ -23,6 +23,9 @@ public class CBConfigUtil {
     }
 
     public static boolean hasQueryService(List<String> services) {
+        if(services == null) {
+            return false;
+        }
         return services.contains("n1ql");
     }
 }


### PR DESCRIPTION
- If the cluster is KV we will use a different way of listing and showing metadata of documents
- Counters are now read from the KV node instead of running counters (muuuuch more efficient)
- Fixed the issue with folding
- Show/hide features if the Query Service is enabled.
- Upgraded the jetbrains version to 2022.3.3
- fixed some issues with deprecated methods